### PR TITLE
Feature/fix deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ module "github_oidc" {
 | -- | -- | -- | -- |
 | `name` | The name of the role. | `string` | Required |
 | `subjects` | A list of GitHub subject values. | `list(string)` | Required |
-| `inline_policies` | A map of inline policies to attach to the role. | `map(string)` | Optional |
+| `policies` | A map of policies to create and attach to the role. The key will be used in the policy name. | `map(string)` | Optional |
 | `managed_policy_arns` | A list of managed policies ARNs to attach to the role. | `list(string)` | Optional
-| `add_oidc_provider` | Whether to add the OIDC provider to the account. | `bool` | `true` |
 | `tags` | A map of tags to add to the role. | `map(string)` | Optional |
 
 ## Outputs

--- a/inputs.tf
+++ b/inputs.tf
@@ -9,9 +9,9 @@ variable "subjects" {
   description = "The list of subjects to allow to assume this role."
 }
 
-variable "inline_policies" {
+variable "policies" {
   type        = map(string)
-  description = "A map of inline policies (JSON) to attach to this role. Keys will be used as the policy name."
+  description = "A map of policies (JSON) to attach to this role. Keys will be used as the policy name."
   default     = {}
 }
 

--- a/inputs.tf
+++ b/inputs.tf
@@ -17,7 +17,7 @@ variable "policies" {
 
 variable "managed_policy_arns" {
   type        = list(string)
-  description = "A list of AWS managed policies arns to attach to this role."
+  description = "A list of AWS managed policy ARNs to attach to this role."
   default     = []
 }
 

--- a/inputs.tf
+++ b/inputs.tf
@@ -21,12 +21,6 @@ variable "managed_policy_arns" {
   default     = []
 }
 
-variable "add_oidc_provider" {
-  type        = bool
-  description = "Whether to add the OIDC provider for GitHub Actions. Default true"
-  default     = true
-}
-
 variable "tags" {
   type        = map(string)
   description = "A map of tags to add to the role."

--- a/main.tf
+++ b/main.tf
@@ -11,14 +11,31 @@ terraform {
 
 data "aws_caller_identity" "current" {}
 
+
+# See if the GitHub OIDC provider already exists
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  # This will return empty if not found, rather than error
+  count = 1
+}
+
+locals {
+  oidc_provider_exists = length(data.aws_iam_openid_connect_provider.github) > 0 && try(data.aws_iam_openid_connect_provider.github[0].arn, "") != ""
+}
+
+# Only create if it doesn't exist
 resource "aws_iam_openid_connect_provider" "github" {
-  count          = var.add_oidc_provider ? 1 : 0
-  client_id_list = ["sts.amazonaws.com"]
-  url            = "https://token.actions.githubusercontent.com"
-  thumbprint_list = [
-    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
-    "6938fd4d98bab03faadb97b34396831e3780aea1"
-  ]
+  count = local.oidc_provider_exists ? 0 : 1
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# Use this output to reference the ARN regardless of creation method
+locals {
+  oidc_provider_arn = local.oidc_provider_exists ? data.aws_iam_openid_connect_provider.github[0].arn : aws_iam_openid_connect_provider.github[0].arn
 }
 
 resource "aws_iam_role" "github_actions" {
@@ -38,7 +55,7 @@ resource "aws_iam_role" "github_actions" {
                 },
                 "Effect":"Allow",
                 "Principal":{
-                    "Federated":"arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+                    "Federated":"${local.oidc_provider_arn}"
                 }
             }
         ],

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,15 @@ resource "aws_iam_role_policy" "policy" {
   role   = aws_iam_role.github_actions.name
   policy = each.value
 }
+
+resource "aws_iam_role_policy_attachment" "managed" {
+  for_each = toset(var.managed_policy_arns)
+
+  role       = aws_iam_role.github_actions.name
+  policy_arn = each.value
+}
+
 output "role_arn" {
   value = aws_iam_role.github_actions.arn
 }
+

--- a/main.tf
+++ b/main.tf
@@ -46,21 +46,18 @@ resource "aws_iam_role" "github_actions" {
     }
   EOF
 
-  dynamic "inline_policy" {
-    for_each = var.inline_policies
-    content {
-      name   = "inline_policy_${inline_policy.key}"
-      policy = inline_policy.value
-    }
-  }
-
-  managed_policy_arns = var.managed_policy_arns
-
   tags = var.tags
 
   max_session_duration = var.max_session_duration
 }
 
+resource "aws_iam_role_policy" "policy" {
+  for_each = var.policies
+
+  name   = "${aws_iam_role.github_actions.name}_${each.key}"
+  role   = aws_iam_role.github_actions.name
+  policy = each.value
+}
 output "role_arn" {
   value = aws_iam_role.github_actions.arn
 }


### PR DESCRIPTION
This pull request updates the `github_oidc` Terraform module to simplify policy management and improve handling of the GitHub OIDC provider. The main changes include renaming the variable for inline policies, improving detection and creation of the OIDC provider, and updating how policies are attached to the IAM role.

**Policy management improvements:**

* Renamed the `inline_policies` variable to `policies` throughout the codebase for clarity, and updated all references and documentation accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-L50) [[2]](diffhunk://#diff-789f251e6364f01fb9e2137e4db484c83871dd3658414b61af35b1e8e67fb148L12-L29)
* Changed the implementation to use `aws_iam_role_policy` resources for each policy in the `policies` map, instead of using inline policies in the role resource.

**OIDC provider handling:**

* Removed the `add_oidc_provider` variable and now automatically checks if the GitHub OIDC provider exists before creating it, preventing duplicate providers. [[1]](diffhunk://#diff-789f251e6364f01fb9e2137e4db484c83871dd3658414b61af35b1e8e67fb148L12-L29) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR14-R38)
* Introduced logic to reference the correct OIDC provider ARN regardless of whether it was created by this module or already existed, and updated the role trust policy to use this ARN. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR14-R38) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL41-R89)

**Other improvements:**

* Updated the description for `managed_policy_arns` for clarity and ensured managed policies are attached using `aws_iam_role_policy_attachment`. [[1]](diffhunk://#diff-789f251e6364f01fb9e2137e4db484c83871dd3658414b61af35b1e8e67fb148L12-L29) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL41-R89)