### PR TITLE
Handle role names exceeding 64 characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,10 +59,11 @@ resource "aws_iam_openid_connect_provider" "github" {
 
 locals {
   oidc_provider_arn = local.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : local.oidc_providers_filtered[0]
+  role_name = length(var.name) > 64 ? substr(var.name, 0, 38) : var.name # truncated to 64 characters
 }
 
 resource "aws_iam_role" "github_actions" {
-  name        = var.name
+  name_prefix        = local.role_name
   description = "${var.name} role for GitHub Actions to assume"
 
   assume_role_policy = <<-EOF
@@ -86,7 +87,10 @@ resource "aws_iam_role" "github_actions" {
     }
   EOF
 
-  tags = var.tags
+  tags = merge(var.tags, {
+    CreatedByOidcModuleId = random_uuid.this.result
+    FullRoleName = replace(var.name, "/[^\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]/", "_")
+  })
 
   max_session_duration = var.max_session_duration
 }

--- a/main.tf
+++ b/main.tf
@@ -59,11 +59,13 @@ resource "aws_iam_openid_connect_provider" "github" {
 
 locals {
   oidc_provider_arn = local.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : local.oidc_providers_filtered[0]
-  role_name = length(var.name) > 64 ? substr(var.name, 0, 38) : var.name # truncated to 64 characters
+  role_name         = length(var.name) > 64 ? null : var.name 
+  role_name_prefix  = length(var.name) > 64 ? substr(var.name, 0, 38) : null # truncated to 38 characters, max for prefix
 }
 
 resource "aws_iam_role" "github_actions" {
-  name_prefix        = local.role_name
+  name        = local.role_name
+  name_prefix = local.role_name_prefix
   description = "${var.name} role for GitHub Actions to assume"
 
   assume_role_policy = <<-EOF


### PR DESCRIPTION
This pull request makes improvements to the IAM role resource definition for GitHub Actions in the Terraform configuration. The main changes ensure that role names comply with AWS length limits and that additional metadata is added to the role's tags for better traceability.

Key changes:

**IAM Role Naming Improvements:**
* Introduced a new local variable `role_name` to ensure the IAM role name does not exceed AWS's 64-character limit by truncating the name if necessary. The role now uses `name_prefix` instead of `name` for better handling of long names.

**Tagging Enhancements:**
* Enhanced the `tags` for the IAM role by merging in two new tags: `CreatedByOidcModuleId` (using a generated UUID for traceability) and `FullRoleName` (sanitized version of the original name), providing more context and traceability for created roles.